### PR TITLE
Log.setLevel() could return the old level

### DIFF
--- a/src/main/java/org/nustaq/kontraktor/util/Log.java
+++ b/src/main/java/org/nustaq/kontraktor/util/Log.java
@@ -50,10 +50,15 @@ public class Log extends Actor<Log> {
     }
 
     /**
+     * Sets the logging level to the specified value.
+     *
      * @param level = Log.DEBUG | Log.INFO | Log.WARN | Log.ERROR
+     * @return the previously set severity
      */
-    public static void setLevel( int level ) {
+    public static int setLevel( int level ) {
+        int oldSeverity = Lg.getSeverity();
         Lg.setSeverity(level);
+        return oldSeverity;
     }
     public static void Info( Object source, String msg ) {
         Lg.info(source, msg);


### PR DESCRIPTION
This is very useful when you just want to dodge some excessive logging.

Hey boss, I recently wanted to make one of my tests quieter during the Maven build by the "classic" increase logger level, run, decrease logger level dance but Log does not seem to offer a visible level output. I thought the very method that sets a logging level could return the previous level (C++ STD style), so I amended it.

What do you think? It shouldn't be noticeable in terms of performance as setLevel is not something that should be getting called a lot.
