### PR TITLE
Could de.ruedigermoeller:kontraktor-web:4.30 drop off redundant dependencies to loose weight? 

### DIFF
--- a/modules/kontraktor-web/pom.xml
+++ b/modules/kontraktor-web/pom.xml
@@ -107,6 +107,52 @@
             <groupId>de.ruedigermoeller</groupId>
             <artifactId>kontraktor-http</artifactId>
             <version>4.30</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.websocket</groupId>
+                    <artifactId>javax.websocket-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>javax.servlet-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.javascript</groupId>
+                    <artifactId>closure-compiler-externs</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.code.findbugs</groupId>
+                    <artifactId>jsr305</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.jsinterop</groupId>
+                    <artifactId>jsinterop-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jboss.spec.javax.websocket</groupId>
+                    <artifactId>jboss-websocket-api_1.1_spec</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.errorprone</groupId>
+                    <artifactId>error_prone_annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.j2objc</groupId>
+                    <artifactId>j2objc-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jboss.spec.javax.servlet</groupId>
+                    <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>animal-sniffer-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jboss.spec.javax.annotation</groupId>
+                    <artifactId>jboss-annotations-api_1.2_spec</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
@RuedigerMoeller Hi, I am a user of project **_de.ruedigermoeller:kontraktor-web:4.30_**. I found that its pom file introduced **_54_** dependencies. However, among them, **_11_** libraries (**_20%_**) have not been used by your project (the redundant dependencies are listed below). Reduce these useless dependencies can help prevent conflicts between library versions. MeanWhile, it can minimize the total added size to projects. It can also help enable advanced scenarios for users of your package. 
This PR helps **_de.ruedigermoeller:kontraktor-web:4.30_** lose weight :) I have tested the revised configuration in my local environment. It is safe to remove the unused libraries.

Best regards


## Redundant dependencies----
<pre><code>
org.codehaus.mojo:animal-sniffer-annotations:jar:1.14:compile
com.google.jsinterop:jsinterop-annotations:jar:1.0.0:compile
com.google.code.findbugs:jsr305:jar:3.0.1:compile
org.jboss.spec.javax.annotation:jboss-annotations-api_1.2_spec:jar:1.0.0.Final:compile
org.jboss.spec.javax.servlet:jboss-servlet-api_3.1_spec:jar:1.0.0.Final:compile
javax.websocket:javax.websocket-api:jar:1.1:compile
com.google.j2objc:j2objc-annotations:jar:1.1:compile
com.google.javascript:closure-compiler-externs:jar:v20181008:compile
com.google.errorprone:error_prone_annotations:jar:2.3.1:compile
javax.servlet:javax.servlet-api:jar:3.1.0:compile
org.jboss.spec.javax.websocket:jboss-websocket-api_1.1_spec:jar:1.1.0.Final:compile
</code></pre>