### PR TITLE
Could de.ruedigermoeller:kontraktor-web:4.30 drop off redundant dependencies? 

### DIFF
--- a/modules/kontraktor-web/pom.xml
+++ b/modules/kontraktor-web/pom.xml
@@ -107,6 +107,52 @@
             <groupId>de.ruedigermoeller</groupId>
             <artifactId>kontraktor-http</artifactId>
             <version>4.30</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.websocket</groupId>
+                    <artifactId>javax.websocket-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>javax.servlet-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.jsinterop</groupId>
+                    <artifactId>jsinterop-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.code.findbugs</groupId>
+                    <artifactId>jsr305</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jboss.spec.javax.websocket</groupId>
+                    <artifactId>jboss-websocket-api_1.1_spec</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.errorprone</groupId>
+                    <artifactId>error_prone_annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.javascript</groupId>
+                    <artifactId>closure-compiler-externs</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jboss.spec.javax.servlet</groupId>
+                    <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>animal-sniffer-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jboss.spec.javax.annotation</groupId>
+                    <artifactId>jboss-annotations-api_1.2_spec</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.j2objc</groupId>
+                    <artifactId>j2objc-annotations</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Hi! I found the pom file of project **_de.ruedigermoeller:kontraktor-web:4.30_** introduced **_54_** dependencies. However, among them, **_11_** libraries (**_20%_**) are not used by your project. I list the redundant dependencies below (labelled as red ones in the figure):
## Redundant dependencies
org.codehaus.mojo:animal-sniffer-annotations:jar:1.14:compile
com.google.jsinterop:jsinterop-annotations:jar:1.0.0:compile
com.google.code.findbugs:jsr305:jar:3.0.1:compile
org.jboss.spec.javax.annotation:jboss-annotations-api_1.2_spec:jar:1.0.0.Final:compile
org.jboss.spec.javax.servlet:jboss-servlet-api_3.1_spec:jar:1.0.0.Final:compile
javax.websocket:javax.websocket-api:jar:1.1:compile
com.google.j2objc:j2objc-annotations:jar:1.1:compile
com.google.javascript:closure-compiler-externs:jar:v20181008:compile
com.google.errorprone:error_prone_annotations:jar:2.3.1:compile
javax.servlet:javax.servlet-api:jar:3.1.0:compile
org.jboss.spec.javax.websocket:jboss-websocket-api_1.1_spec:jar:1.1.0.Final:compile
## Outdated dependencies
org.jboss.spec.javax.websocket:jboss-websocket-api_1.1_spec:1.1.0.Final (**_3230_** days without maintenance)
com.google.jsinterop:jsinterop-annotations:1.0.0 (**_2557_** days without maintenance)
javax.websocket:javax.websocket-api:1.1 (**_3279_** days without maintenance)
org.jboss.spec.javax.servlet:jboss-servlet-api_3.1_spec:1.0.0.Final (**_3580_** days without maintenance)
org.codehaus.mojo:animal-sniffer-annotations:1.14 (**_3076_** days without maintenance)
com.google.j2objc:j2objc-annotations:1.1 (**_2559_** days without maintenance)
javax.servlet:javax.servlet-api:3.1.0 (**_3747_** days without maintenance)
org.jboss.spec.javax.annotation:jboss-annotations-api_1.2_spec:1.0.0.Final (**_3581_** days without maintenance)

---
Removing the redundant dependencies can reduce the size of project and prevent potential dependency conflict issues (i.e., multiple versions of the same library). More importantly, one of the redundant dependencies **_org.jboss.spec.javax.servlet:jboss-servlet-api_3.1_spec:jar:1.0.0.Final:compile_** incorporates an incompatible license COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (COMMON DEVELOPMENT AND DISTRIBUTION LICENSE cannot be used by the project with license LGPL 3), one of the redundant dependencies **_org.jboss.spec.javax.websocket:jboss-websocket-api_1.1_spec:jar:1.1.0.Final:compile_** incorporates an incompatible license COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (COMMON DEVELOPMENT AND DISTRIBUTION LICENSE cannot be used by the project with license LGPL 3). As such, I suggest a refactoring operation for **_de.ruedigermoeller:kontraktor-web:4.30_**’s pom file.

The attached PR helps resolve the reported problem. It is safe to remove the unused libraries (we considered Java reflection relations when analyzing the dependencies). These changes have passed **_de.ruedigermoeller:kontraktor-web:4.30_**’s maven tests.

Best regards