### PR TITLE
add verbosity

### DIFF
--- a/modules/kontraktor-http/pom.xml
+++ b/modules/kontraktor-http/pom.xml
@@ -112,7 +112,7 @@
         <dependency>
             <groupId>de.ruedigermoeller</groupId>
             <artifactId>kontraktor</artifactId>
-            <version>5.1.11</version>
+            <version>5.1.13</version>
         </dependency>
 
         <dependency>

--- a/modules/kontraktor-reallive/pom.xml
+++ b/modules/kontraktor-reallive/pom.xml
@@ -136,7 +136,7 @@
         <dependency>
             <groupId>de.ruedigermoeller</groupId>
             <artifactId>kontraktor</artifactId>
-            <version>5.1.10</version>
+            <version>5.1.13</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <name>Kontraktor</name>
     <groupId>de.ruedigermoeller</groupId>
     <artifactId>kontraktor</artifactId>
-    <version>5.1.12</version>
+    <version>5.1.13</version>
 
     <description>a light weight, efficient actor lib</description>
     <url>https://github.com/RuedigerMoeller/kontraktor</url>

--- a/src/main/java/org/nustaq/kontraktor/impl/ActorProxyFactory.java
+++ b/src/main/java/org/nustaq/kontraktor/impl/ActorProxyFactory.java
@@ -316,7 +316,7 @@ public class ActorProxyFactory {
                 method.setBody(body);
                 cc.addMethod(method);
 
-                if (verbosity > 0 && originalMethod.getAnnotation(Local.class) != null) {
+                if (verbosity > 0 && originalMethod.getAnnotation(Local.class) == null) {
                     if (verbosity > 1 || !isActorBuiltInMethodName) {
                         final String params = Arrays.stream(originalMethod.getParameterTypes()).map(CtClass::getSimpleName).collect(Collectors.joining(", "));
                         System.out.printf("Endpoint at: %s.%s(%s) -> %s%n", orig.getName(), originalMethod.getName(), params, originalMethod.getReturnType().getSimpleName());

--- a/src/main/java/org/nustaq/kontraktor/impl/ActorProxyFactory.java
+++ b/src/main/java/org/nustaq/kontraktor/impl/ActorProxyFactory.java
@@ -21,6 +21,7 @@ import org.nustaq.kontraktor.annotations.AsCallback;
 import org.nustaq.kontraktor.annotations.CallerSideMethod;
 import javassist.*;
 import javassist.bytecode.AccessFlag;
+import org.nustaq.kontraktor.annotations.Local;
 import org.nustaq.kontraktor.util.Log;
 import org.nustaq.serialization.util.FSTUtil;
 
@@ -315,11 +316,11 @@ public class ActorProxyFactory {
                 method.setBody(body);
                 cc.addMethod(method);
 
-                if(verbosity > 0) {
+                if (verbosity > 0 && originalMethod.getAnnotation(Local.class) != null) {
                     if (verbosity > 1 || !isActorBuiltInMethodName) {
-                        final String params = Arrays.stream(method.getParameterTypes()).map(ctClass -> ctClass.getSimpleName()).collect(Collectors.joining(", "));
-                        System.out.printf("Endpoint at: %s.%s(%s) -> %s%n", cc.getName(), method.getName(), params, method.getReturnType().getSimpleName());
-                    }
+                        final String params = Arrays.stream(originalMethod.getParameterTypes()).map(CtClass::getSimpleName).collect(Collectors.joining(", "));
+                        System.out.printf("Endpoint at: %s.%s(%s) -> %s%n", orig.getName(), originalMethod.getName(), params, originalMethod.getReturnType().getSimpleName());
+                   }
                 }
             } else if ( (method.getModifiers() & (AccessFlag.NATIVE|AccessFlag.FINAL|AccessFlag.STATIC)) == 0 )
             {

--- a/src/test/java/kontraktor/BasicTest.java
+++ b/src/test/java/kontraktor/BasicTest.java
@@ -7,6 +7,7 @@ import org.nustaq.kontraktor.annotations.*;
 import org.nustaq.kontraktor.Promise;
 import org.junit.Test;
 import org.nustaq.kontraktor.impl.ActorBlockedException;
+import org.nustaq.kontraktor.impl.ActorProxyFactory;
 import org.nustaq.kontraktor.impl.DispatcherThread;
 import org.nustaq.kontraktor.util.Log;
 
@@ -27,6 +28,10 @@ import static org.junit.Assert.assertTrue;
  * Created by ruedi on 06.05.14.
  */
 public class BasicTest {
+
+    static {
+        ActorProxyFactory.setVerbosity(1);
+    }
 
     public static class Bench extends Actor<Bench> {
         protected int count;

--- a/src/test/java/kontraktor/BasicTest.java
+++ b/src/test/java/kontraktor/BasicTest.java
@@ -30,7 +30,7 @@ import static org.junit.Assert.assertTrue;
 public class BasicTest {
 
     static {
-        ActorProxyFactory.setVerbosity(1);
+        ActorProxyFactory.setVerbosity(2);
     }
 
     public static class Bench extends Actor<Bench> {


### PR DESCRIPTION
Idea to be able to see easily which endpoints are available by Actor.

Maybe move verbosity flag to Actor class and pass value to ActorProxyFactory - my solution enables it global for now.
Or we could add util-function to query Actor/ActorProxy to give this list, which is printed for now.